### PR TITLE
Write output to buffer instead of file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 CHANGELOG
 
-Version (NEXT)
+Version 0.4
 * Do not render output to file, but rather to a buffer.
   This means that apps using the gem no longer needs write permissions on a filesystem.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 
+Version (NEXT)
+* Do not render output to file, but rather to a buffer.
+  This means that apps using the gem no longer needs write permissions on a filesystem.
+
 Version 0.2
 * Relocation of templates and xslt files
 * Enable gem configuration to set the location of default and custom word templates and xslt.
@@ -22,7 +26,7 @@ Version 0.1.7
 
 Version 0.1.6:
 * Add tables support for borders and headers
- 
+
 Version 0.1.5:
 * Bugfix: h5 & h6 also create w:p's so any wrapping divs dont need to.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Using the default word file as template
 require 'htmltoword'
 
 my_html = '<html><head></head><body><p>Hello</p></body></html>'
-file = Htmltoword::Document.create my_html, file_name
+document = Htmltoword::Document.create(my_html)
 ```
 
 Using your custom word file as a template, where you can setup your own style for normal text, h1,h2, etc.
@@ -34,7 +34,7 @@ require 'htmltoword'
 Htmltoword.config.custom_templates_path = 'some_path'
 
 my_html = '<html><head></head><body><p>Hello</p></body></html>'
-file = Htmltoword::Document.create my_html, file_name, word_template_file_name
+document = Htmltoword::Document.create(my_html, word_template_file_name)
 ```
 
 ### With Rails

--- a/bin/htmltoword
+++ b/bin/htmltoword
@@ -12,8 +12,9 @@ main do |input, output|
   if options[:format] == 'markdown'
     markup = markdown2html(markup)
   end
-  temp = Htmltoword::Document.create markup, output, options[:template_name], options[:extras]
-  FileUtils.cp temp, output
+  File.open(output, "w") do |out|
+    out << Htmltoword::Document.create(markup, options[:template_name], options[:extras])
+  end
   puts "Done" if options[:verbose]
 end
 

--- a/htmltoword.gemspec
+++ b/htmltoword.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "actionpack"
   spec.add_dependency "nokogiri"
-  spec.add_dependency "rubyzip"
+  spec.add_dependency "rubyzip", ">= 1.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/htmltoword/action_controller.rb
+++ b/lib/htmltoword/action_controller.rb
@@ -34,8 +34,8 @@ ActionController::Renderers.add :docx do |filename, options|
   # then it will look for a template.
   content = options.delete(:content) || render_to_string(options)
 
-  doc = Htmltoword::Document.create content, file_name, word_template, extras
-  send_data File.read(doc.path), filename: file_name, type: Mime::DOCX, disposition: disposition
+  document = Htmltoword::Document.create(content, word_template, extras)
+  send_data document, filename: file_name, type: Mime::DOCX, disposition: disposition
 end
 
 if defined? ActionController::Responder

--- a/lib/htmltoword/version.rb
+++ b/lib/htmltoword/version.rb
@@ -1,3 +1,3 @@
 module Htmltoword
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
Instead of writing the generated docx contents to a temporary file,
we now just create a string buffer with the file content.
This makes it easier to use the gem on a system where the application might not
have write access to the filesystem. It also ensures that the gem doesn't leave
behind a lot of temporary files, since there was no system for cleaning them up
after use.

This is also the recommended way of using Rubyzip for modifying docx files:
https://github.com/rubyzip/rubyzip#modify-docx-file-with-rubyzip