### PR TITLE
Bug fix on a particular case of br inside li

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 CHANGELOG
 
+Version 0.4.4
+* Update default template to remove language
+* Bug fix on lists and tables having br elements
+
 Version 0.4.3
 * Add method that generates and saves the document to a file in a specific file path
 

--- a/lib/htmltoword/version.rb
+++ b/lib/htmltoword/version.rb
@@ -1,3 +1,3 @@
 module Htmltoword
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -49,11 +49,19 @@
     </w:p>
   </xsl:template>
 
-  <xsl:template match="br[not(ancestor::p) and not(ancestor::div) and not(name(..)='td') and not(name(..)='li') or preceding-sibling::div or following-sibling::div
-                        or preceding-sibling::p or following-sibling::p]">
+
+  <xsl:template match="br[not(ancestor::p) and not(ancestor::div) and not(name(..)='td') and not(name(..)='li') or
+                          (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
     <w:p>
       <w:r></w:r>
     </w:p>
+  </xsl:template>
+
+  <xsl:template match="br[(name(..)='li' or name(..)='td') and
+                          (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
+    <w:r>
+      <w:br />
+    </w:r>
   </xsl:template>
 
   <xsl:template match="br">

--- a/spec/xslt_breaks_spec.rb
+++ b/spec/xslt_breaks_spec.rb
@@ -164,6 +164,10 @@ describe "XSLT to align div, p and td tags" do
       <li>Text <br> new line</li>
       <li><div>Text inside div <br> new line</div></li>
       <li><p>Text inside p <br> new line</p></li>
+      <li>Some text
+        <br>
+        <div>Text in div</div>
+      </li>
     </ol>
   </body>
   </html>
@@ -223,6 +227,24 @@ describe "XSLT to align div, p and td tags" do
       <w:t xml:space="preserve"> new line</w:t>
     </w:r>
   </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="1"/>
+      </w:numPr>
+    </w:pPr>
+    <w:r>
+      <w:t xml:space="preserve">Some text </w:t>
+    </w:r>
+    <w:r>
+      <w:br/>
+    </w:r>
+    <w:r>
+      <w:t xml:space="preserve">Text in div</w:t>
+    </w:r>
+  </w:p>
     EOL
     compare_resulting_wordml_with_expected(html, expected_wordml.strip)
   end
@@ -244,6 +266,10 @@ describe "XSLT to align div, p and td tags" do
               <li><div>Text inside div <br> new line</div></li>
               <li><p>Text inside p <br> new line</p></li>
             </ul>
+          </td>
+          <td>Some text
+            <br>
+            <p>Text inside p</p>
           </td>
         </tr>
       </tbody>
@@ -353,6 +379,24 @@ describe "XSLT to align div, p and td tags" do
           </w:r>
           <w:r>
             <w:t xml:space="preserve"> new line</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Some text </w:t>
+          </w:r>
+        </w:p>
+        <w:p>
+          <w:r>
+            <w:br/>
+          </w:r>
+        </w:p>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Text inside p</w:t>
           </w:r>
         </w:p>
       </w:tc>


### PR DESCRIPTION
This PR fixes a bug of br tags inside a list element when the list has text elements and a div or p tag 

Fixes the translation of this scenario
```
<li>Some text
  <br>
  <div>Content inside a div</div>
</li>
```