### PR TITLE
Handle external links inside html

### DIFF
--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -36,8 +36,16 @@ module Htmltoword
         'word/numbering.xml'
       end
 
+      def relations_xml_file
+        'word/_rels/document.xml.rels'
+      end
+
       def numbering_xslt
         File.join(Htmltoword.config.default_xslt_path, 'numbering.xslt')
+      end
+
+      def relations_xslt
+        File.join(Htmltoword.config.default_xslt_path, 'relations.xslt')
       end
 
       def xslt_template(extras = false)
@@ -76,6 +84,7 @@ module Htmltoword
       html = html.presence || '<body></body>'
       source = Nokogiri::HTML(html.gsub(/>\s+</, '><'))
       transform_and_replace(source, Document.numbering_xslt, Document.numbering_xml_file)
+      transform_and_replace(source, Document.relations_xslt, Document.relations_xml_file)
       transform_and_replace(source, Document.xslt_template(extras), file_name, extras)
     end
 

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -18,6 +18,7 @@
   <xsl:output method="xml" encoding="utf-8" omit-xml-declaration="yes" indent="yes" />
   <xsl:include href="./functions.xslt"/>
   <xsl:include href="./tables.xslt"/>
+  <xsl:include href="./links.xslt"/>
 
   <xsl:template match="/">
     <xsl:apply-templates />
@@ -152,7 +153,14 @@
         The div template will not create a w:p because the div contains a h2. Therefore we need to wrap the inline elements span|a|small in a p here.
       </xsl:comment>
     <w:p>
-      <xsl:apply-templates />
+      <xsl:choose>
+        <xsl:when test="self::a">
+          <xsl:call-template name="link" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates />
+        </xsl:otherwise>
+      </xsl:choose>
     </w:p>
   </xsl:template>
 

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -154,7 +154,7 @@
       </xsl:comment>
     <w:p>
       <xsl:choose>
-        <xsl:when test="self::a">
+        <xsl:when test="self::a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]">
           <xsl:call-template name="link" />
         </xsl:when>
         <xsl:otherwise>

--- a/lib/htmltoword/xslt/links.xslt
+++ b/lib/htmltoword/xslt/links.xslt
@@ -1,0 +1,35 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                xmlns:o="urn:schemas-microsoft-com:office:office"
+                xmlns:v="urn:schemas-microsoft-com:vml"
+                xmlns:WX="http://schemas.microsoft.com/office/word/2003/auxHint"
+                xmlns:aml="http://schemas.microsoft.com/aml/2001/core"
+                xmlns:w10="urn:schemas-microsoft-com:office:word"
+                xmlns:pkg="http://schemas.microsoft.com/office/2006/xmlPackage"
+                xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+                xmlns:ext="http://www.xmllab.net/wordml2html/ext"
+                xmlns:java="http://xml.apache.org/xalan/java"
+                xmlns:str="http://exslt.org/strings"
+                xmlns:func="http://exslt.org/functions"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                version="1.0"
+                exclude-result-prefixes="java msxsl ext w o v WX aml w10"
+                extension-element-prefixes="func">
+
+  <xsl:template match="a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]" name="link">
+    <w:hyperlink>
+      <xsl:attribute name="r:id">rId<xsl:value-of select="count(preceding::a) + 8" /></xsl:attribute>
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space="preserve">
+          <xsl:value-of select="."/>
+        </w:t>
+      </w:r>
+    </w:hyperlink>
+  </xsl:template>
+</xsl:stylesheet>

--- a/lib/htmltoword/xslt/links.xslt
+++ b/lib/htmltoword/xslt/links.xslt
@@ -19,7 +19,7 @@
 
   <xsl:template match="a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]" name="link">
     <w:hyperlink>
-      <xsl:attribute name="r:id">rId<xsl:value-of select="count(preceding::a) + 8" /></xsl:attribute>
+      <xsl:attribute name="r:id">rId<xsl:value-of select="count(preceding::a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]) + 8" /></xsl:attribute>
       <w:r>
         <w:rPr>
           <w:rStyle w:val="Hyperlink"/>

--- a/lib/htmltoword/xslt/relations.xslt
+++ b/lib/htmltoword/xslt/relations.xslt
@@ -1,0 +1,26 @@
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns="http://schemas.openxmlformats.org/package/2006/relationships"
+                version="1.0">
+  <xsl:output method="xml" encoding="utf-8" omit-xml-declaration="yes" indent="yes" />
+
+  <xsl:template match="a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]" priority="1">
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{@href}" TargetMode="External">
+      <xsl:attribute name="Id">rId<xsl:value-of select="count(preceding::a) + 8"/></xsl:attribute>
+    </Relationship>
+  </xsl:template>
+
+  <xsl:template match="/">
+    <Relationships>
+      <Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects" Target="stylesWithEffects.xml"/>
+      <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>
+      <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" Target="webSettings.xml"/>
+      <Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/>
+      <Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+      <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+      <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+      <xsl:apply-templates select="*"/>
+    </Relationships>
+  </xsl:template>
+
+  <xsl:template match="text()|@*"/>
+</xsl:stylesheet>

--- a/lib/htmltoword/xslt/relations.xslt
+++ b/lib/htmltoword/xslt/relations.xslt
@@ -5,7 +5,7 @@
 
   <xsl:template match="a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]" priority="1">
     <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{@href}" TargetMode="External">
-      <xsl:attribute name="Id">rId<xsl:value-of select="count(preceding::a) + 8"/></xsl:attribute>
+      <xsl:attribute name="Id">rId<xsl:value-of select="count(preceding::a[starts-with(@href, 'http://') or starts-with(@href, 'https://')]) + 8"/></xsl:attribute>
     </Relationship>
   </xsl:template>
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,15 @@ def compare_numbering_xml(html, expected_xml)
   expect(remove_whitespace(result.to_s)).to eq(remove_whitespace(expected_xml))
 end
 
+def compare_relations_xml(html, expected_xml)
+  source = Nokogiri::HTML(html.gsub(/>\s+</, "><"))
+  xslt = Nokogiri::XSLT(File.open(Htmltoword::Document.relations_xslt))
+  result = xslt.transform(source)
+  result.xpath('//comment()').remove
+  result = remove_declaration(result.to_s)
+  expect(remove_whitespace(result.to_s)).to eq(remove_whitespace(expected_xml))
+end
+
 private
 
 def html_fixture_path(file_name)

--- a/spec/xslt_links_spec.rb
+++ b/spec/xslt_links_spec.rb
@@ -8,11 +8,15 @@ describe "XSLT for Links" do
   <html>
   <head></head>
   <body>
+    <a href="/internal">This is internal link.</a>
     <div>
       <a href="http://somelink.com">Link text.</a>
     </div>
     <div>
       <a href="https://someotherlink.com">Other link text.</a>
+    </div>
+    <div>
+      <a href="/internal2">This is other internal link.</a>
     </div>
     <div>
       <a href="http://someotherlink2.com">Other link text 2.</a>
@@ -28,6 +32,11 @@ describe "XSLT for Links" do
   </html>
     EOL
     expected_wordml = <<-EOL
+  <w:p>
+    <w:r>
+      <w:t xml:space=\"preserve\">This is internal link.</w:t>
+    </w:r>
+  </w:p>
   <w:p>
     <w:hyperlink r:id="rId8">
       <w:r>
@@ -51,6 +60,11 @@ describe "XSLT for Links" do
         <w:t xml:space="preserve">Other link text.</w:t>
       </w:r>
     </w:hyperlink>
+  </w:p>
+  <w:p>
+    <w:r>
+      <w:t xml:space=\"preserve\">This is other internal link.</w:t>
+    </w:r>
   </w:p>
   <w:p>
     <w:hyperlink r:id=\"rId10\">

--- a/spec/xslt_links_spec.rb
+++ b/spec/xslt_links_spec.rb
@@ -1,0 +1,128 @@
+require 'spec_helper'
+
+describe "XSLT for Links" do
+
+  it "transforms heading tags in a div" do
+    html = <<-EOL
+  <!DOCTYPE html>
+  <html>
+  <head></head>
+  <body>
+    <div>
+      <a href="http://somelink.com">Link text.</a>
+    </div>
+    <div>
+      <a href="https://someotherlink.com">Other link text.</a>
+    </div>
+    <div>
+      <a href="http://someotherlink2.com">Other link text 2.</a>
+      <div>
+        <a href="http://someotherlink3.com">Other link text 3.</a>
+      </div>
+      Some text
+      <ul>
+        <li>First item: <a href="http://listlink.com">List link text.</a></li>
+      </ul>
+    </div>
+  </body>
+  </html>
+    EOL
+    expected_wordml = <<-EOL
+  <w:p>
+    <w:hyperlink r:id="rId8">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space="preserve">Link text.</w:t>
+      </w:r>
+    </w:hyperlink>
+  </w:p>
+  <w:p>
+    <w:hyperlink r:id="rId9">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space="preserve">Other link text.</w:t>
+      </w:r>
+    </w:hyperlink>
+  </w:p>
+  <w:p>
+    <w:hyperlink r:id=\"rId10\">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val=\"Hyperlink\"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space=\"preserve\">Other link text 2.</w:t>
+      </w:r>
+    </w:hyperlink>
+  </w:p>
+  <w:p>
+    <w:hyperlink r:id=\"rId11\">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val=\"Hyperlink\"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space=\"preserve\">Other link text 3.</w:t>
+      </w:r>
+    </w:hyperlink>
+  </w:p>
+  <w:p>
+    <w:r>
+      <w:t xml:space="preserve"> Some text </w:t>
+    </w:r>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="1"/>
+      </w:numPr>
+    </w:pPr>
+    <w:r>
+      <w:t xml:space="preserve">First item: </w:t>
+    </w:r>
+    <w:hyperlink r:id="rId12">
+      <w:r>
+        <w:rPr>
+          <w:rStyle w:val="Hyperlink"/>
+          <w:color w:val="000080"/>
+          <w:u w:val="single"/>
+        </w:rPr>
+        <w:t xml:space="preserve">List link text.</w:t>
+      </w:r>
+    </w:hyperlink>
+  </w:p>
+    EOL
+
+    expected_relations_xml = <<-EOL
+  <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId3" Type="http://schemas.microsoft.com/office/2007/relationships/stylesWithEffects" Target="stylesWithEffects.xml"/>
+    <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings" Target="settings.xml"/>
+    <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings" Target="webSettings.xml"/>
+    <Relationship Id="rId6" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/>
+    <Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme" Target="theme/theme1.xml"/>
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+    <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="http://somelink.com" TargetMode="External" Id="rId8"/>
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://someotherlink.com" TargetMode="External" Id="rId9"/>
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="http://someotherlink2.com" TargetMode="External" Id="rId10"/>
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="http://someotherlink3.com" TargetMode="External" Id="rId11"/>
+    <Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="http://listlink.com" TargetMode="External" Id="rId12"/>
+  </Relationships>
+    EOL
+
+    compare_resulting_wordml_with_expected(html, expected_wordml.strip)
+    compare_relations_xml(html, expected_relations_xml)
+  end
+end


### PR DESCRIPTION
### Changes
* Added support for handling external links(tag "a" with href: http:// and https://)
* In order to support canonical hyperlink tag, puts new links into `relations.xml` according to: http://officeopenxml.com/WPhyperlink.php