### PR TITLE
Add basic support for pre tag

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ Version 0.4.4
 * Update default template to remove language
 * Bug fixes on lists and tables having br elements
 * Bug fixes on lists having inline elements and div or p tags
+* Bug fix on corrupted docx files generated in Windows
+* Add basic support to 'pre' tag
 
 Version 0.4.3
 * Add method that generates and saves the document to a file in a specific file path

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -70,7 +70,13 @@
     </w:r>
   </xsl:template>
 
-  <xsl:template match="div[not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li)]">
+  <xsl:template match="pre">
+    <w:p>
+      <xsl:apply-templates />
+    </w:p>
+  </xsl:template>
+
+  <xsl:template match="div[not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not (descendant::pre)]">
     <xsl:comment>Divs should create a p if nothing above them has and nothing below them will</xsl:comment>
     <w:p>
       <xsl:call-template name="text-alignment" />
@@ -156,7 +162,7 @@
     </w:p>
   </xsl:template>
 
-  <xsl:template match="text()[not(parent::li) and not(parent::td) and (preceding-sibling::h1 or preceding-sibling::h2 or preceding-sibling::h3 or preceding-sibling::h4 or preceding-sibling::h5 or preceding-sibling::h6 or preceding-sibling::table or preceding-sibling::p or preceding-sibling::ol or preceding-sibling::ul or preceding-sibling::div or following-sibling::h1 or following-sibling::h2 or following-sibling::h3 or following-sibling::h4 or following-sibling::h5 or following-sibling::h6 or following-sibling::table or following-sibling::p or following-sibling::ol or following-sibling::ul or following-sibling::div)]">
+  <xsl:template match="text()[not(parent::li) and not(parent::td) and not(parent::pre) and (preceding-sibling::h1 or preceding-sibling::h2 or preceding-sibling::h3 or preceding-sibling::h4 or preceding-sibling::h5 or preceding-sibling::h6 or preceding-sibling::table or preceding-sibling::p or preceding-sibling::ol or preceding-sibling::ul or preceding-sibling::div or following-sibling::h1 or following-sibling::h2 or following-sibling::h3 or following-sibling::h4 or following-sibling::h5 or following-sibling::h6 or following-sibling::table or following-sibling::p or following-sibling::ol or following-sibling::ul or following-sibling::div)]">
     <xsl:comment>
         In the following situation:
 

--- a/spec/xslt_spec.rb
+++ b/spec/xslt_spec.rb
@@ -35,4 +35,10 @@ describe "XSLT" do
     html = '<html><head></head><body><div><p>Hello</p><details><summary>Title</summary><p>Second</p><details></div></body></html>'
     compare_resulting_wordml_with_expected(html, "<w:p> <w:r> <w:t xml:space=\"preserve\">Hello</w:t> </w:r> </w:p>")
   end
+
+  it "Should transform a pre" do
+     html = '<pre>Lorem ipsum </pre><pre><b>Boldie...</b> Not boldie</pre><div><div><pre>dolor sit amet <i>Italic</i></pre> <div>consectetur </div></div>adipiscing <pre>elit <a href="/linkto">link </a></pre></div><div><h1>Title</h1><pre>Pre 1</pre><pre>Pre 2</pre><pre>Pre 3</pre></div>'
+     expected = '<w:p> <w:r> <w:t xml:space="preserve">Lorem ipsum </w:t> </w:r> </w:p> <w:p> <w:r> <w:rPr> <w:b/> </w:rPr> <w:t xml:space="preserve">Boldie...</w:t> </w:r> <w:r> <w:t xml:space="preserve"> Not boldie</w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">dolor sit amet </w:t> </w:r> <w:r> <w:rPr> <w:i/> </w:rPr> <w:t xml:space="preserve">Italic</w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">consectetur </w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">adipiscing </w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">elit </w:t> </w:r> <w:r> <w:t xml:space="preserve">link </w:t> </w:r> </w:p> <w:p> <w:pPr> <w:pStyle w:val="Heading1"/> </w:pPr> <w:r> <w:t xml:space="preserve">Title</w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">Pre 1</w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">Pre 2</w:t> </w:r> </w:p> <w:p> <w:r> <w:t xml:space="preserve">Pre 3</w:t> </w:r> </w:p>'
+     compare_resulting_wordml_with_expected(html, expected)
+  end
 end


### PR DESCRIPTION
This PR adds basic support for the ```<pre>``` tag, so documents doesn't get corrupted when finding one of these. 

It is transformed as a normal block container. Proper transformation of spacing elements might come later. 