### PR TITLE
Fix broken rails html email detection. 

### DIFF
--- a/lib/htmltoword/action_controller.rb
+++ b/lib/htmltoword/action_controller.rb
@@ -6,7 +6,7 @@ unless defined? Mime::DOCX
 end
 
 ActionController::Renderers.add :docx do |filename, options|
-  formats[0] = :docx unless formats.include?(:docx) || Rails.version < '3.2'
+  formats << :docx unless formats.include?(:docx) || Rails.version < '3.2'
 
   # This is ugly and should be solved with regular file utils
   if options[:template] == action_name


### PR DESCRIPTION
I noticed that `formats[0]` already contain `:html`. As soon as i render a docx, hence overwrite the html format entry, rails no longer render email in html format. Rails must use this variable to detect views like `email.text.erb` and `email.html.erb`.

I wonder if we really need to add the `:docx` in `formats`. I am on rails 4.2.4 and everything worked as expected without this line.
