### PR TITLE
Handle complex lists

### DIFF
--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -85,7 +85,8 @@ module Htmltoword
       source = Nokogiri::HTML(html.gsub(/>\s+</, '><'))
       transform_and_replace(source, Document.numbering_xslt, Document.numbering_xml_file)
       transform_and_replace(source, Document.relations_xslt, Document.relations_xml_file)
-      transform_and_replace(source, Document.xslt_template(extras), file_name, extras)
+      cleaned_source = Nokogiri::XSLT(File.open(File.join(Htmltoword.config.default_xslt_path, 'inline_elements.xslt'))).transform(source)
+      transform_and_replace(cleaned_source, Document.xslt_template(extras), file_name, extras)
     end
 
     private

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -110,31 +110,72 @@
   </xsl:template>
 
   <xsl:template match="ol|ul">
-    <xsl:param name="local_level" select="0"/>
     <xsl:param name="global_level" select="count(preceding::ol[not(ancestor::ol or ancestor::ul)]) + count(preceding::ul[not(ancestor::ol or ancestor::ul)]) + 1"/>
     <xsl:apply-templates>
-      <xsl:with-param name="local_level" select="$local_level + 1" />
       <xsl:with-param name="global_level" select="$global_level" />
     </xsl:apply-templates>
   </xsl:template>
 
-  <xsl:template match="li">
-    <xsl:param name="local_level" />
+  <xsl:template name="listItem" match="li">
     <xsl:param name="global_level" />
-    <w:p>
-      <w:pPr>
-        <w:pStyle w:val="ListParagraph"></w:pStyle>
-        <w:numPr>
-          <w:ilvl w:val="{$local_level - 1}"/>
-          <w:numId w:val="{$global_level}"/>
-        </w:numPr>
-      </w:pPr>
-      <xsl:apply-templates select="*[not(name()='ol' or name()='ul')]|text()"/>
-    </w:p>
-    <xsl:apply-templates select="./ol|./ul">
-      <xsl:with-param name="local_level" select="$local_level" />
-      <xsl:with-param name="global_level" select="$global_level" />
-    </xsl:apply-templates>
+    <xsl:param name="preceding-siblings" select="0"/>
+    <xsl:for-each select="node()">
+      <xsl:choose>
+        <xsl:when test="self::br">
+          <w:p>
+            <w:pPr>
+              <w:pStyle w:val="ListParagraph"></w:pStyle>
+              <w:numPr>
+                <w:ilvl w:val="0"/>
+                <w:numId w:val="0"/>
+              </w:numPr>
+            </w:pPr>
+            <w:r></w:r>
+          </w:p>
+        </xsl:when>
+        <xsl:when test="self::ol|self::ul">
+          <xsl:apply-templates>
+            <xsl:with-param name="global_level" select="$global_level" />
+          </xsl:apply-templates>
+        </xsl:when>
+        <xsl:when test="not(descendant::li)"> <!-- simpler div, p, headings, etc... -->
+          <xsl:variable name="ilvl" select="count(ancestor::ol) + count(ancestor::ul) - 1"></xsl:variable>
+          <xsl:choose>
+            <xsl:when test="$preceding-siblings + count(preceding-sibling::*) > 0">
+              <w:p>
+                <w:pPr>
+                  <w:pStyle w:val="ListParagraph"></w:pStyle>
+                  <w:numPr>
+                    <w:ilvl w:val="0"/>
+                    <w:numId w:val="0"/>
+                  </w:numPr>
+                  <w:ind w:left="{720 * ($ilvl + 2)}" w:hanging="720"/>
+                </w:pPr>
+                <xsl:apply-templates/>
+              </w:p>
+            </xsl:when>
+            <xsl:otherwise>
+              <w:p>
+                <w:pPr>
+                  <w:pStyle w:val="ListParagraph"></w:pStyle>
+                  <w:numPr>
+                    <w:ilvl w:val="{$ilvl}"/>
+                    <w:numId w:val="{$global_level}"/>
+                  </w:numPr>
+                </w:pPr>
+                <xsl:apply-templates/>
+              </w:p>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise> <!-- mixed things div having list and stuff content... -->
+          <xsl:call-template name="listItem">
+            <xsl:with-param name="global_level" select="$global_level" />
+            <xsl:with-param name="preceding-siblings" select="$preceding-siblings + count(preceding-sibling::*)" />
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
   </xsl:template>
 
   <xsl:template match="span[not(ancestor::td) and not(ancestor::li) and (preceding-sibling::h1 or preceding-sibling::h2 or preceding-sibling::h3 or preceding-sibling::h4 or preceding-sibling::h5 or preceding-sibling::h6 or preceding-sibling::table or preceding-sibling::p or preceding-sibling::ol or preceding-sibling::ul or preceding-sibling::div or following-sibling::h1 or following-sibling::h2 or following-sibling::h3 or following-sibling::h4 or following-sibling::h5 or following-sibling::h6 or following-sibling::table or following-sibling::p or following-sibling::ol or following-sibling::ul or following-sibling::div)]

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -51,14 +51,14 @@
   </xsl:template>
 
 
-  <xsl:template match="br[not(ancestor::p) and not(ancestor::div) and not(name(..)='td') and not(name(..)='li') or
+  <xsl:template match="br[not(ancestor::p) and not(ancestor::div) and not(ancestor::td|ancestor::li) or
                           (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
     <w:p>
       <w:r></w:r>
     </w:p>
   </xsl:template>
 
-  <xsl:template match="br[(name(..)='li' or name(..)='td') and
+  <xsl:template match="br[(ancestor::li or ancestor::td) and
                           (preceding-sibling::div or following-sibling::div or preceding-sibling::p or following-sibling::p)]">
     <w:r>
       <w:br />

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -149,7 +149,7 @@
                     <w:ilvl w:val="0"/>
                     <w:numId w:val="0"/>
                   </w:numPr>
-                  <w:ind w:left="{720 * ($ilvl + 2)}" w:hanging="720"/>
+                  <w:ind w:left="{720 * ($ilvl + 1)}"/>
                 </w:pPr>
                 <xsl:apply-templates/>
               </w:p>

--- a/lib/htmltoword/xslt/inline_elements.xslt
+++ b/lib/htmltoword/xslt/inline_elements.xslt
@@ -11,11 +11,11 @@
   </xsl:template>
 
   <!-- get first inline element of a sequence or text having block element siblings... -->
-  <xsl:template match="node()[self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()][../div]">
+  <xsl:template match="node()[self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()][parent::div|parent::li]">
     <div>
       <xsl:call-template name="inlineElement"/>
     </div>
-    <xsl:apply-templates select="following-sibling::node()[not((self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text())[../div])][1]"/>
+    <xsl:apply-templates select="following-sibling::node()[not((self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text())[parent::div|parent::li])][1]"/>
   </xsl:template>
 
   <!-- get following inline elements... -->

--- a/lib/htmltoword/xslt/inline_elements.xslt
+++ b/lib/htmltoword/xslt/inline_elements.xslt
@@ -1,0 +1,37 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output encoding="utf-8" omit-xml-declaration="yes" indent="yes" />
+
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()[1]"/>
+    </xsl:copy>
+    <xsl:apply-templates select="following-sibling::node()[1]"/>
+  </xsl:template>
+
+  <!-- get first inline element of a sequence or text having block element siblings... -->
+  <xsl:template match="node()[self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()][../div]">
+    <div>
+      <xsl:call-template name="inlineElement"/>
+    </div>
+    <xsl:apply-templates select="following-sibling::node()[not((self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text())[../div])][1]"/>
+  </xsl:template>
+
+  <!-- get following inline elements... -->
+  <xsl:template match="a[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |b[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |em[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |i[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |small[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |span[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |strong[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |u[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]
+    |text()[preceding-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]]"
+    name="inlineElement">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()[1]"/>
+    </xsl:copy>
+    <xsl:apply-templates select="following-sibling::node()[1][self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()]"/>
+  </xsl:template>
+</xsl:stylesheet>

--- a/lib/htmltoword/xslt/inline_elements.xslt
+++ b/lib/htmltoword/xslt/inline_elements.xslt
@@ -11,11 +11,13 @@
   </xsl:template>
 
   <!-- get first inline element of a sequence or text having block element siblings... -->
-  <xsl:template match="node()[self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()][parent::div|parent::li]">
+  <xsl:template match="node()[self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text()][parent::div|parent::li|parent::td]">
     <div>
+      <xsl:attribute name="class"><xsl:value-of select="../@class"/></xsl:attribute>
+      <xsl:attribute name="style"><xsl:value-of select="../@style"/></xsl:attribute>
       <xsl:call-template name="inlineElement"/>
     </div>
-    <xsl:apply-templates select="following-sibling::node()[not((self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text())[parent::div|parent::li])][1]"/>
+    <xsl:apply-templates select="following-sibling::node()[not((self::a|self::b|self::em|self::i|self::small|self::span|self::strong|self::u|self::text())[parent::div|parent::li|parent::td])][1]"/>
   </xsl:template>
 
   <!-- get following inline elements... -->

--- a/spec/fixtures/wordml/lists_inline_elements.xml
+++ b/spec/fixtures/wordml/lists_inline_elements.xml
@@ -15,9 +15,26 @@
   <w:r>
     <w:t xml:space="preserve"> and some more text </w:t>
   </w:r>
-  <w:r>
-    <w:br/>
-  </w:r>
+</w:p>
+<w:p>
+  <w:pPr>
+    <w:pStyle w:val="ListParagraph"/>
+    <w:numPr>
+      <w:ilvl w:val="0"/>
+      <w:numId w:val="0"/>
+    </w:numPr>
+  </w:pPr>
+  <w:r/>
+</w:p>
+<w:p>
+  <w:pPr>
+    <w:pStyle w:val="ListParagraph"/>
+    <w:numPr>
+      <w:ilvl w:val="0"/>
+      <w:numId w:val="0"/>
+    </w:numPr>
+    <w:ind w:left="1440" w:hanging="720"/>
+  </w:pPr>
   <w:r>
     <w:t xml:space="preserve">Text in a new line in div</w:t>
   </w:r>
@@ -39,9 +56,26 @@
 <w:r>
   <w:t xml:space="preserve">) and some more text </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">Text in a new line in div</w:t>
 </w:r>
@@ -84,9 +118,26 @@
 <w:r>
   <w:t xml:space="preserve"> and again normal </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
 </w:r>
@@ -111,9 +162,26 @@
 <w:r>
   <w:t xml:space="preserve"> and normal text </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
 </w:r>
@@ -138,9 +206,26 @@
 <w:r>
   <w:t xml:space="preserve"> and normal text </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
 </w:r>
@@ -165,9 +250,26 @@
 <w:r>
   <w:t xml:space="preserve"> and normal text </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
 </w:r>
@@ -192,9 +294,26 @@
 <w:r>
   <w:t xml:space="preserve"> and normal text </w:t>
 </w:r>
-<w:r>
-  <w:br/>
-</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+</w:pPr>
+<w:r/>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:pStyle w:val="ListParagraph"/>
+  <w:numPr>
+    <w:ilvl w:val="0"/>
+    <w:numId w:val="0"/>
+  </w:numPr>
+  <w:ind w:left="1440" w:hanging="720"/>
+</w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
 </w:r>

--- a/spec/fixtures/wordml/lists_inline_elements.xml
+++ b/spec/fixtures/wordml/lists_inline_elements.xml
@@ -33,7 +33,7 @@
       <w:ilvl w:val="0"/>
       <w:numId w:val="0"/>
     </w:numPr>
-    <w:ind w:left="1440" w:hanging="720"/>
+    <w:ind w:left="720"/>
   </w:pPr>
   <w:r>
     <w:t xml:space="preserve">Text in a new line in div</w:t>
@@ -74,7 +74,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">Text in a new line in div</w:t>
@@ -136,7 +136,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
@@ -180,7 +180,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
@@ -224,7 +224,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
@@ -268,7 +268,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>
@@ -312,7 +312,7 @@
     <w:ilvl w:val="0"/>
     <w:numId w:val="0"/>
   </w:numPr>
-  <w:ind w:left="1440" w:hanging="720"/>
+  <w:ind w:left="720"/>
 </w:pPr>
 <w:r>
   <w:t xml:space="preserve">New paragraph</w:t>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,8 +10,9 @@ end
 
 def compare_resulting_wordml_with_expected(html, resulting_wordml, extras: false)
   source = Nokogiri::HTML(html.gsub(/>\s+</, "><"))
+  cleaned_source = Nokogiri::XSLT(File.open(File.join(Htmltoword.config.default_xslt_path, 'inline_elements.xslt'))).transform(source)
   xslt = Nokogiri::XSLT(File.open(Htmltoword::Document.xslt_template(extras)))
-  result = xslt.transform(source)
+  result = xslt.transform(cleaned_source)
   result.xpath('//comment()').remove
   result = remove_declaration(result.to_s)
   expect(remove_whitespace(result.to_s)).to eq(remove_whitespace(resulting_wordml))

--- a/spec/xslt_breaks_spec.rb
+++ b/spec/xslt_breaks_spec.rb
@@ -206,7 +206,7 @@ describe "XSLT to align div, p and td tags" do
         <w:ilvl w:val="0"/>
         <w:numId w:val="0"/>
       </w:numPr>
-      <w:ind w:left="1440" w:hanging="720"/>
+      <w:ind w:left="720"/>
     </w:pPr>
     <w:r>
       <w:t xml:space="preserve"> new line</w:t>
@@ -277,7 +277,7 @@ describe "XSLT to align div, p and td tags" do
         <w:ilvl w:val="0"/>
         <w:numId w:val="0"/>
       </w:numPr>
-      <w:ind w:left="1440" w:hanging="720"/>
+      <w:ind w:left="720"/>
     </w:pPr>
     <w:r>
       <w:t xml:space="preserve">Text in div</w:t>
@@ -394,7 +394,7 @@ describe "XSLT to align div, p and td tags" do
               <w:ilvl w:val="0"/>
               <w:numId w:val="0"/>
             </w:numPr>
-            <w:ind w:left="1440" w:hanging="720"/>
+            <w:ind w:left="720"/>
           </w:pPr>
           <w:r>
             <w:t xml:space="preserve"> new line</w:t>

--- a/spec/xslt_breaks_spec.rb
+++ b/spec/xslt_breaks_spec.rb
@@ -99,9 +99,11 @@ describe "XSLT to align div, p and td tags" do
     <w:r>
       <w:t xml:space="preserve"> Lorem ipsum 4 </w:t>
     </w:r>
-    <w:r>
-      <w:br/>
-    </w:r>
+  </w:p>
+  <w:p>
+    <w:r/>
+  </w:p>
+  <w:p>
     <w:r>
       <w:t xml:space="preserve"> Lorem ipsum 5 </w:t>
     </w:r>
@@ -110,9 +112,11 @@ describe "XSLT to align div, p and td tags" do
     <w:r>
       <w:t xml:space="preserve"> Lorem ipsum 6 </w:t>
     </w:r>
-    <w:r>
-      <w:br/>
-    </w:r>
+  </w:p>
+  <w:p>
+    <w:r/>
+  </w:p>
+  <w:p>
     <w:r>
       <w:t xml:space="preserve"> Lorem ipsum 7 </w:t>
     </w:r>
@@ -184,9 +188,26 @@ describe "XSLT to align div, p and td tags" do
     <w:r>
       <w:t xml:space="preserve">Text </w:t>
     </w:r>
-    <w:r>
-      <w:br/>
-    </w:r>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="0"/>
+      </w:numPr>
+    </w:pPr>
+    <w:r/>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="0"/>
+      </w:numPr>
+      <w:ind w:left="1440" w:hanging="720"/>
+    </w:pPr>
     <w:r>
       <w:t xml:space="preserve"> new line</w:t>
     </w:r>
@@ -238,9 +259,26 @@ describe "XSLT to align div, p and td tags" do
     <w:r>
       <w:t xml:space="preserve">Some text </w:t>
     </w:r>
-    <w:r>
-      <w:br/>
-    </w:r>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="0"/>
+      </w:numPr>
+    </w:pPr>
+    <w:r/>
+  </w:p>
+  <w:p>
+    <w:pPr>
+      <w:pStyle w:val="ListParagraph"/>
+      <w:numPr>
+        <w:ilvl w:val="0"/>
+        <w:numId w:val="0"/>
+      </w:numPr>
+      <w:ind w:left="1440" w:hanging="720"/>
+    </w:pPr>
     <w:r>
       <w:t xml:space="preserve">Text in div</w:t>
     </w:r>
@@ -338,9 +376,26 @@ describe "XSLT to align div, p and td tags" do
           <w:r>
             <w:t xml:space="preserve">Text </w:t>
           </w:r>
-          <w:r>
-            <w:br/>
-          </w:r>
+        </w:p>
+        <w:p>
+          <w:pPr>
+            <w:pStyle w:val="ListParagraph"/>
+            <w:numPr>
+              <w:ilvl w:val="0"/>
+              <w:numId w:val="0"/>
+            </w:numPr>
+          </w:pPr>
+          <w:r/>
+        </w:p>
+        <w:p>
+          <w:pPr>
+            <w:pStyle w:val="ListParagraph"/>
+            <w:numPr>
+              <w:ilvl w:val="0"/>
+              <w:numId w:val="0"/>
+            </w:numPr>
+            <w:ind w:left="1440" w:hanging="720"/>
+          </w:pPr>
           <w:r>
             <w:t xml:space="preserve"> new line</w:t>
           </w:r>

--- a/spec/xslt_lists_spec.rb
+++ b/spec/xslt_lists_spec.rb
@@ -387,42 +387,6 @@ describe "XSLT supporting lists" do
           <w:ind w:left="1440" w:hanging="360"/>
         </w:pPr>
       </w:lvl>
-      <w:lvl w:ilvl="2">
-        <w:start w:val="1"/>
-        <w:numFmt w:val="decimal"/>
-        <w:lvlText w:val="%3."/>
-        <w:lvlJc w:val="left"/>
-        <w:pPr>
-          <w:ind w:left="2160" w:hanging="360"/>
-        </w:pPr>
-      </w:lvl>
-      <w:lvl w:ilvl="3">
-        <w:start w:val="1"/>
-        <w:numFmt w:val="decimal"/>
-        <w:lvlText w:val="%4."/>
-        <w:lvlJc w:val="left"/>
-        <w:pPr>
-          <w:ind w:left="2880" w:hanging="360"/>
-        </w:pPr>
-      </w:lvl>
-      <w:lvl w:ilvl="4">
-        <w:start w:val="1"/>
-        <w:numFmt w:val="decimal"/>
-        <w:lvlText w:val="%5."/>
-        <w:lvlJc w:val="left"/>
-        <w:pPr>
-          <w:ind w:left="3600" w:hanging="360"/>
-        </w:pPr>
-      </w:lvl>
-      <w:lvl w:ilvl="5">
-        <w:start w:val="1"/>
-        <w:numFmt w:val="decimal"/>
-        <w:lvlText w:val="%6."/>
-        <w:lvlJc w:val="left"/>
-        <w:pPr>
-          <w:ind w:left="4320" w:hanging="360"/>
-        </w:pPr>
-      </w:lvl>
       <w:lvl w:ilvl="1">
         <w:start w:val="1"/>
         <w:numFmt w:val="lowerLetter"/>
@@ -443,30 +407,39 @@ describe "XSLT supporting lists" do
       </w:lvl>
       <w:lvl w:ilvl="3">
         <w:start w:val="1"/>
-        <w:numFmt w:val="lowerRoman"/>
-        <w:lvlText w:val="%4."/>
+        <w:numFmt w:val="bullet"/>
+        <w:lvlText w:val="■"/>
         <w:lvlJc w:val="left"/>
         <w:pPr>
           <w:ind w:left="2880" w:hanging="360"/>
         </w:pPr>
+        <w:rPr>
+          <w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/>
+        </w:rPr>
       </w:lvl>
       <w:lvl w:ilvl="4">
         <w:start w:val="1"/>
-        <w:numFmt w:val="lowerRoman"/>
-        <w:lvlText w:val="%5."/>
+        <w:numFmt w:val="bullet"/>
+        <w:lvlText w:val="■"/>
         <w:lvlJc w:val="left"/>
         <w:pPr>
           <w:ind w:left="3600" w:hanging="360"/>
         </w:pPr>
+        <w:rPr>
+          <w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/>
+        </w:rPr>
       </w:lvl>
       <w:lvl w:ilvl="5">
         <w:start w:val="1"/>
-        <w:numFmt w:val="lowerRoman"/>
-        <w:lvlText w:val="%6."/>
+        <w:numFmt w:val="bullet"/>
+        <w:lvlText w:val="■"/>
         <w:lvlJc w:val="left"/>
         <w:pPr>
           <w:ind w:left="4320" w:hanging="360"/>
         </w:pPr>
+        <w:rPr>
+          <w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/>
+        </w:rPr>
       </w:lvl>
     </w:abstractNum>
     <w:num w:numId="1">

--- a/spec/xslt_simple_text_style_spec.rb
+++ b/spec/xslt_simple_text_style_spec.rb
@@ -625,8 +625,6 @@ More on combinations : </w:t>
           <w:r>
             <w:t xml:space="preserve">Text: </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:rPr>
               <w:b/>
@@ -648,8 +646,6 @@ More on combinations : </w:t>
             </w:rPr>
             <w:t xml:space="preserve"> Strong </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:rPr>
               <w:b/>
@@ -671,8 +667,6 @@ More on combinations : </w:t>
             </w:rPr>
             <w:t xml:space="preserve"> More bold. </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:t xml:space="preserve"> End </w:t>
           </w:r>
@@ -684,8 +678,6 @@ More on combinations : </w:t>
           <w:r>
             <w:t xml:space="preserve">Text: </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:rPr>
               <w:i/>
@@ -707,8 +699,6 @@ More on combinations : </w:t>
             </w:rPr>
             <w:t xml:space="preserve"> More em text </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:rPr>
               <w:i/>
@@ -730,8 +720,6 @@ More on combinations : </w:t>
             </w:rPr>
             <w:t xml:space="preserve"> More italic.</w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:t xml:space="preserve">  End </w:t>
           </w:r>
@@ -844,8 +832,6 @@ More on combinations : </w:t>
           <w:r>
             <w:t xml:space="preserve">Td </w:t>
           </w:r>
-        </w:p>
-        <w:p>
           <w:r>
             <w:t xml:space="preserve">Span</w:t>
           </w:r>


### PR DESCRIPTION
This PR enhances the list parsing, allowing a bit more complex things such as 
```html
<li>
  <div>Lorem ipsum...</div>
  <br>
  </div> Ipsum lorem... </div>
</li>
```

It also has a bit better handling of inline elements, grouping them into a single parent and then rendering them in the same paragraph.
