### PR TITLE
Fix mutation of ActionView::Base.default_formats

### DIFF
--- a/lib/htmltoword/action_controller.rb
+++ b/lib/htmltoword/action_controller.rb
@@ -6,7 +6,9 @@ unless defined? Mime::DOCX
 end
 
 ActionController::Renderers.add :docx do |filename, options|
-  formats[0] = :docx unless formats.include?(:docx) || Rails.version < '3.2'
+  unless formats.include?(:docx) || Rails.version < '3.2'
+    self.formats = [:docx] + formats
+  end
 
   # This is ugly and should be solved with regular file utils
   if options[:template] == action_name


### PR DESCRIPTION
When a render is done without a proper request context, the `formats` object fallback on `ActionView::Base.default_formats`. This could happen when a render is done in a background job for instance.

By doing `formats[0] = :docx`, it mutates the `ActionView::Base.default_formats` and breaks the following renders.

The `ActionView::LookupContext` which exposes the `formats` object to the render has a [api](https://github.com/rails/rails/blob/73521d586981279a99d3ba038d62e2414125df7a/actionview/lib/action_view/lookup_context.rb#L32) to manipulate formats without mutating the `default_formats`. This allows to add the `:docx` format as primary format in this render without breaking the following ones.