### PR TITLE
Support for Rails 5

### DIFF
--- a/lib/htmltoword/railtie.rb
+++ b/lib/htmltoword/railtie.rb
@@ -1,7 +1,7 @@
 module Htmltoword
   class Railtie < ::Rails::Railtie
     initializer 'htmltoword.setup' do
-      unless defined? Mime::DOCX
+      unless defined? Mime[:docx]
         Mime::Type.register 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', :docx
       end
 

--- a/lib/htmltoword/railtie.rb
+++ b/lib/htmltoword/railtie.rb
@@ -1,7 +1,7 @@
 module Htmltoword
   class Railtie < ::Rails::Railtie
     initializer 'htmltoword.setup' do
-      unless defined? Mime[:docx]
+      if defined?(Mime) and Mime[:docx].nil?
         Mime::Type.register 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', :docx
       end
 

--- a/lib/htmltoword/renderer.rb
+++ b/lib/htmltoword/renderer.rb
@@ -18,7 +18,7 @@ module Htmltoword
 
     def send_file
       document = Htmltoword::Document.create(@content, @word_template, @use_extras)
-      @context.send_data(document, filename: @file_name, type: Mime::DOCX, disposition: @disposition)
+      @context.send_data(document, filename: @file_name, type: Mime[:docx], disposition: @disposition)
     end
 
     private


### PR DESCRIPTION
Access Mime type with `Mime::DOCX` is deprecated now use `Mime[:docx]` #51 