### PR TITLE
Edit spec_helper to pass all tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ def compare_content_of_body?(wordml)
 end
 
 def remove_whitespace(wordml)
-  wordml.gsub(/\s+/, ' ').gsub(/>\s+</, '><').strip
+  wordml.gsub(/\s+/, ' ').gsub(/(?<keep>>)\s+|\s+(?<keep><)/, '\k<keep>').strip
 end
 
 def remove_declaration(wordml)


### PR DESCRIPTION
Test `XSLT for Links transforms heading tags in a div` was broken because of bad regexp during comparison.

Now remove all whitespaces before `<` and after `>`.