### PR TITLE
Remove extra whitespace from <a href> tags in DOCX

### DIFF
--- a/lib/htmltoword/xslt/links.xslt
+++ b/lib/htmltoword/xslt/links.xslt
@@ -27,9 +27,7 @@
           <w:color w:val="000080"/>
           <w:u w:val="single"/>
         </w:rPr>
-        <w:t xml:space="preserve">
-          <xsl:value-of select="."/>
-        </w:t>
+        <w:t xml:space="preserve"><xsl:value-of select="."/></w:t>
       </w:r>
     </w:hyperlink>
   </xsl:template>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,14 @@ def compare_relations_xml(html, expected_xml)
   expect(remove_whitespace(result.to_s)).to eq(remove_whitespace(expected_xml))
 end
 
+def check_link_text(html, resulting_wordml, extras: false)
+  source = Nokogiri::HTML(html.gsub(/>\s+</, '><'))
+  result = Htmltoword::Document.new(template_file(nil)).transform_doc_xml(source, extras)
+  result.gsub!(/\s*<!--(.*?)-->\s*/m, '')
+  result = remove_declaration(result)
+  expect(remove_whitespace_for_link_check(result)).to eq(remove_whitespace_for_link_check(resulting_wordml))
+end
+
 private
 
 def fixture_path(folder, file_name, extension)
@@ -54,6 +62,10 @@ end
 
 def remove_whitespace(wordml)
   wordml.gsub(/\s+/, ' ').gsub(/(?<keep>>)\s+|\s+(?<keep><)/, '\k<keep>').strip
+end
+
+def remove_whitespace_for_link_check(wordml)
+  wordml.gsub(/^\s+/, '')
 end
 
 def remove_declaration(wordml)

--- a/spec/xslt_links_spec.rb
+++ b/spec/xslt_links_spec.rb
@@ -22,9 +22,7 @@ describe "XSLT for Links" do
       <a href="http://someotherlink2.com">Other link text 2.</a>
       <div>
         <a href="http://someotherlink3.com">Other link text 3.</a>
-      </div>
-      Some text
-      <ul>
+      </div> Some text <ul>
         <li>First item: <a href="http://listlink.com">List link text.</a></li>
       </ul>
     </div>
@@ -36,8 +34,7 @@ describe "XSLT for Links" do
     <w:r>
       <w:t xml:space=\"preserve\">This is internal link.</w:t>
     </w:r>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:hyperlink r:id="rId8">
       <w:r>
         <w:rPr>
@@ -48,8 +45,7 @@ describe "XSLT for Links" do
         <w:t xml:space="preserve">Link text.</w:t>
       </w:r>
     </w:hyperlink>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:hyperlink r:id="rId9">
       <w:r>
         <w:rPr>
@@ -60,13 +56,11 @@ describe "XSLT for Links" do
         <w:t xml:space="preserve">Other link text.</w:t>
       </w:r>
     </w:hyperlink>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:r>
       <w:t xml:space=\"preserve\">This is other internal link.</w:t>
     </w:r>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:hyperlink r:id=\"rId10\">
       <w:r>
         <w:rPr>
@@ -77,8 +71,7 @@ describe "XSLT for Links" do
         <w:t xml:space=\"preserve\">Other link text 2.</w:t>
       </w:r>
     </w:hyperlink>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:hyperlink r:id=\"rId11\">
       <w:r>
         <w:rPr>
@@ -89,13 +82,11 @@ describe "XSLT for Links" do
         <w:t xml:space=\"preserve\">Other link text 3.</w:t>
       </w:r>
     </w:hyperlink>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:r>
       <w:t xml:space="preserve"> Some text </w:t>
     </w:r>
-  </w:p>
-  <w:p>
+  </w:p><w:p>
     <w:pPr>
       <w:pStyle w:val="ListParagraph"/>
       <w:numPr>
@@ -138,5 +129,7 @@ describe "XSLT for Links" do
 
     compare_resulting_wordml_with_expected(html, expected_wordml.strip)
     compare_relations_xml(html, expected_relations_xml)
+    check_link_text(html, expected_wordml)
+
   end
 end


### PR DESCRIPTION
This caused extra spaces to appear within the link text in \<a href\> tags, resulting in display like this: `__________Link_Text________`
Fixes DMPRoadmap/roadmap#1185