### PR TITLE
Do not include images if dimensions are not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ To create page breaks simply add a div with class -page-break ie:
 <div class="-page-break"></div>
 ````
 
+### Images
+Support for images is very basic and is only possible for external images(i.e accessed via URL). If the image doesn't 
+have correctly defined it's width and height it won't be included in the document
+
+**Limitations:**
+- Images are external i.e. pictures accessed via URL, not stored within document
+- only sizing is customisable
+
+Examples:
+```html
+<img src="http://placehold.it/250x100.png" style="width: 250px; height: 100px">
+<img src="http://placehold.it/250x100.png" data-width="250px" data-height="100px">
+<img src="http://placehold.it/250x100.png" data-height="150px" style="width:250px; height:100px">
+```
+
 ## Contributing / Extending
 
 Word docx files are essentially just a zipped collection of xml files and resources.

--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -91,7 +91,8 @@ module Htmltoword
 
     def replace_files(html, extras = false)
       html = '<body></body>' if html.nil? || html.empty?
-      source = Nokogiri::HTML(html.gsub(/>\s+</, '><'))
+      original_source = Nokogiri::HTML(html.gsub(/>\s+</, '><'))
+      source = xslt(stylesheet_name: 'cleanup').transform(original_source)
       transform_and_replace(source, xslt_path('numbering'), Document.numbering_xml_file)
       transform_and_replace(source, xslt_path('relations'), Document.relations_xml_file)
       transform_doc_xml(source, extras)

--- a/lib/htmltoword/version.rb
+++ b/lib/htmltoword/version.rb
@@ -1,3 +1,3 @@
 module Htmltoword
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end

--- a/lib/htmltoword/xslt/cleanup.xslt
+++ b/lib/htmltoword/xslt/cleanup.xslt
@@ -23,6 +23,7 @@
   <xsl:template match="command"/>
   <xsl:template match="font"/>
   <xsl:template match="iframe"/>
+  <xsl:template match="img[not(starts-with(@src, 'http://')) and not(starts-with(@src, 'https://'))]"/>
   <xsl:template match="isindex"/>
   <xsl:template match="map"/>
   <xsl:template match="noframes"/>

--- a/lib/htmltoword/xslt/images.xslt
+++ b/lib/htmltoword/xslt/images.xslt
@@ -37,62 +37,69 @@
   <xsl:include href="./image_functions.xslt"/>
 
   <xsl:template match="img|body/img" name="image">
-    <w:drawing>
-      <wp:inline distT="0" distB="0" distL="0" distR="0">
-        <wp:extent>
-          <xsl:call-template name="image-dimention-attributes"/>
-        </wp:extent>
-        <wp:effectExtent l="0" t="0" r="0" b="0"/>
-        <wp:docPr>
-          <xsl:attribute name="id"><xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
-          <xsl:attribute name="name">Picture <xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
-        </wp:docPr>
-        <wp:cNvGraphicFramePr>
-          <a:graphicFrameLocks noChangeAspect="1"/>
-        </wp:cNvGraphicFramePr>
-        <a:graphic>
-          <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
-            <pic:pic>
-              <pic:nvPicPr>
-                <pic:cNvPr>
-                  <xsl:attribute name="id"><xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
-                  <xsl:attribute name="title"><xsl:value-of select="@alt" /></xsl:attribute>
-                  <xsl:attribute name="name"><xsl:call-template name="image-name">
-                      <xsl:with-param name="source" select="@src"/>
-                      <xsl:with-param name="data-filename" select="@data-filename"/>
-                    </xsl:call-template></xsl:attribute>
-                </pic:cNvPr>
-                <pic:cNvPicPr/>
-              </pic:nvPicPr>
-              <pic:blipFill>
-                <a:blip>
-                  <xsl:attribute name="r:embed"><xsl:call-template name="relationship-id"/></xsl:attribute>
-                  <a:extLst>
-                    <a:ext uri="{{28A0092B-C50C-407E-A947-70E740481C1C}}">
-                      <a14:useLocalDpi val="0"/>
-                    </a:ext>
-                  </a:extLst>
-                </a:blip>
-                <a:stretch>
-                  <a:fillRect/>
-                </a:stretch>
-              </pic:blipFill>
-              <pic:spPr>
-                <a:xfrm>
-                  <a:off x="0" y="0"/>
-                  <a:ext>
-                    <xsl:call-template name="image-dimention-attributes"/>
-                  </a:ext>
-                </a:xfrm>
-                <a:prstGeom prst="rect">
-                  <a:avLst/>
-                </a:prstGeom>
-              </pic:spPr>
-            </pic:pic>
-          </a:graphicData>
-        </a:graphic>
-      </wp:inline>
-    </w:drawing>
+    <xsl:choose>
+      <xsl:when test="not(@data-width) and not(@data-height) and not(contains(@style, 'width')) and not(contains(@style, 'height'))">
+        <!-- Do not transfor images unless width and height are correctly specified -->
+      </xsl:when>
+      <xsl:otherwise>
+        <w:drawing>
+          <wp:inline distT="0" distB="0" distL="0" distR="0">
+            <wp:extent>
+              <xsl:call-template name="image-dimention-attributes"/>
+            </wp:extent>
+            <wp:effectExtent l="0" t="0" r="0" b="0"/>
+            <wp:docPr>
+              <xsl:attribute name="id"><xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
+              <xsl:attribute name="name">Picture <xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
+            </wp:docPr>
+            <wp:cNvGraphicFramePr>
+              <a:graphicFrameLocks noChangeAspect="1"/>
+            </wp:cNvGraphicFramePr>
+            <a:graphic>
+              <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+                <pic:pic>
+                  <pic:nvPicPr>
+                    <pic:cNvPr>
+                      <xsl:attribute name="id"><xsl:value-of select="count(preceding::img)+1" /></xsl:attribute>
+                      <xsl:attribute name="title"><xsl:value-of select="@alt" /></xsl:attribute>
+                      <xsl:attribute name="name"><xsl:call-template name="image-name">
+                        <xsl:with-param name="source" select="@src"/>
+                        <xsl:with-param name="data-filename" select="@data-filename"/>
+                      </xsl:call-template></xsl:attribute>
+                    </pic:cNvPr>
+                    <pic:cNvPicPr/>
+                  </pic:nvPicPr>
+                  <pic:blipFill>
+                    <a:blip>
+                      <xsl:attribute name="r:embed"><xsl:call-template name="relationship-id"/></xsl:attribute>
+                      <a:extLst>
+                        <a:ext uri="{{28A0092B-C50C-407E-A947-70E740481C1C}}">
+                          <a14:useLocalDpi val="0"/>
+                        </a:ext>
+                      </a:extLst>
+                    </a:blip>
+                    <a:stretch>
+                      <a:fillRect/>
+                    </a:stretch>
+                  </pic:blipFill>
+                  <pic:spPr>
+                    <a:xfrm>
+                      <a:off x="0" y="0"/>
+                      <a:ext>
+                        <xsl:call-template name="image-dimention-attributes"/>
+                      </a:ext>
+                    </a:xfrm>
+                    <a:prstGeom prst="rect">
+                      <a:avLst/>
+                    </a:prstGeom>
+                  </pic:spPr>
+                </pic:pic>
+              </a:graphicData>
+            </a:graphic>
+          </wp:inline>
+        </w:drawing>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!--

--- a/spec/xslt_images_spec.rb
+++ b/spec/xslt_images_spec.rb
@@ -13,6 +13,11 @@ describe "XSLT to include images" do
     <p><img src="https://placehold.it/250x150.png" data-height="150px" style="width:250px; height:100px"></p>
     <p><img src="https://placehold.it/150x150.png" data-width="150px" data-height="150px" style="width:250px; height:100px"></p>
     <p><img src="https://placehold.it/150x150.png" data-width="150px" data-height="150px"></p>
+    <p><img src="https://placehold.it/150x150.png"></p>
+    <p><img src="https://placehold.it/150x150.png" style="border-radius: 8px;"></p>
+    <div class="mediaobject">
+      <img alt="" src="/placehold.it/150x150.png">
+    </div>
     </body>
   </html>
     EOL
@@ -276,12 +281,13 @@ describe "XSLT to include images" do
       </wp:inline>
     </w:drawing>
     </w:p>
+    <w:p/>
+    <w:p/>
+    <w:p/>
     EOL
-
 
     compare_resulting_wordml_with_expected(html, expected_wordml.strip)
   end
-
 
   it "generates correct relations" do
     html = <<-EOL


### PR DESCRIPTION
Currently if the html has images without width and height specified, the document generation will fail. 

This PR removes the image in order to be able to generate a document without the image, which was the default behaviour before enabling external images in https://github.com/karnov/htmltoword/pull/44