### PR TITLE
Add basic support for description lists

### DIFF
--- a/lib/htmltoword/version.rb
+++ b/lib/htmltoword/version.rb
@@ -1,3 +1,3 @@
 module Htmltoword
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -77,7 +77,7 @@
     </w:p>
   </xsl:template>
 
-  <xsl:template match="div[not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not (descendant::pre)]">
+  <xsl:template match="div[not(ancestor::li) and not(ancestor::td) and not(ancestor::th) and not(ancestor::p) and not(ancestor::dl) and not(descendant::dl) and not(descendant::div) and not(descendant::p) and not(descendant::h1) and not(descendant::h2) and not(descendant::h3) and not(descendant::h4) and not(descendant::h5) and not(descendant::h6) and not(descendant::table) and not(descendant::li) and not (descendant::pre)]">
     <xsl:comment>Divs should create a p if nothing above them has and nothing below them will</xsl:comment>
     <w:p>
       <xsl:call-template name="text-alignment" />
@@ -176,6 +176,25 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="dl">
+    <xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="dt">
+    <w:p>
+      <xsl:apply-templates/>
+    </w:p>
+  </xsl:template>
+
+  <xsl:template match="dd">
+    <w:p>
+      <w:pPr>
+        <w:ind w:left="720"/>
+      </w:pPr>
+      <xsl:apply-templates/>
+    </w:p>
   </xsl:template>
 
   <xsl:template match="span[not(ancestor::td) and not(ancestor::li) and (preceding-sibling::h1 or preceding-sibling::h2 or preceding-sibling::h3 or preceding-sibling::h4 or preceding-sibling::h5 or preceding-sibling::h6 or preceding-sibling::table or preceding-sibling::p or preceding-sibling::ol or preceding-sibling::ul or preceding-sibling::div or following-sibling::h1 or following-sibling::h2 or following-sibling::h3 or following-sibling::h4 or following-sibling::h5 or following-sibling::h6 or following-sibling::table or following-sibling::p or following-sibling::ol or following-sibling::ul or following-sibling::div)]

--- a/spec/fixtures/description_lists/test01.html
+++ b/spec/fixtures/description_lists/test01.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+<!-- Single term and description -->
+<dl>
+  <dt>Firefox</dt>
+  <dd>
+    A free, open source, cross-platform,
+    graphical web browser developed by the
+    Mozilla Corporation and hundreds of
+    volunteers.
+  </dd>
+</dl>
+</body>
+</html>

--- a/spec/fixtures/description_lists/test01.xml
+++ b/spec/fixtures/description_lists/test01.xml
@@ -1,0 +1,13 @@
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Firefox</w:t>
+  </w:r>
+</w:p>
+<w:p>
+  <w:pPr>
+    <w:ind w:left="720"/>
+  </w:pPr>
+  <w:r>
+    <w:t xml:space="preserve">A free, open source, cross-platform, graphical web browser developed by the Mozilla Corporation and hundreds of volunteers. </w:t>
+  </w:r>
+</w:p>

--- a/spec/fixtures/description_lists/test02.html
+++ b/spec/fixtures/description_lists/test02.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+<!-- Multiple terms, single description -->
+<dl>
+  <dt>Firefox</dt>
+  <dt>Mozilla Firefox</dt>
+  <dt>Fx</dt>
+  <dd>
+    A free, open source, cross-platform,
+    graphical web browser developed by the
+    Mozilla Corporation and hundreds of
+    volunteers.
+  </dd>
+</dl>
+</body>
+</html>

--- a/spec/fixtures/description_lists/test02.xml
+++ b/spec/fixtures/description_lists/test02.xml
@@ -1,0 +1,23 @@
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Firefox</w:t>
+  </w:r>
+</w:p>
+<w:p>
+<w:r>
+  <w:t xml:space="preserve">Mozilla Firefox</w:t>
+</w:r>
+</w:p>
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Fx</w:t>
+  </w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:ind w:left="720"/>
+</w:pPr>
+<w:r>
+  <w:t xml:space="preserve">A free, open source, cross-platform, graphical web browser developed by the Mozilla Corporation and hundreds of volunteers. </w:t>
+</w:r>
+</w:p>

--- a/spec/fixtures/description_lists/test03.html
+++ b/spec/fixtures/description_lists/test03.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+<!-- Single term, multiple descriptions -->
+<dl>
+  <dt>Firefox</dt>
+  <dd>
+    A free, open source, cross-platform,
+    graphical web browser developed by the
+    Mozilla Corporation and hundreds of
+    volunteers.
+  </dd>
+  <dd>
+    The Red Panda also known as the Lesser
+    Panda, Wah, Bear Cat or Firefox, is a
+    mostly herbivorous mammal, slightly larger
+    than a domestic cat (60 cm long).
+  </dd>
+</dl>
+</body>
+</html>

--- a/spec/fixtures/description_lists/test03.xml
+++ b/spec/fixtures/description_lists/test03.xml
@@ -1,0 +1,21 @@
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Firefox</w:t>
+  </w:r>
+</w:p>
+<w:p>
+  <w:pPr>
+    <w:ind w:left="720"/>
+  </w:pPr>
+  <w:r>
+    <w:t xml:space="preserve">A free, open source, cross-platform, graphical web browser developed by the Mozilla Corporation and hundreds of volunteers.</w:t>
+  </w:r>
+</w:p>
+<w:p>
+  <w:pPr>
+    <w:ind w:left="720"/>
+  </w:pPr>
+  <w:r>
+    <w:t xml:space="preserve">The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox, is a mostly herbivorous mammal, slightly larger than a domestic cat (60 cm long).</w:t>
+  </w:r>
+</w:p>

--- a/spec/fixtures/description_lists/test04.html
+++ b/spec/fixtures/description_lists/test04.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head></head>
+<body>
+<div id="test-container">
+  <h1>Heading</h1>
+  Some text
+  <div>
+    <dl>
+      <dt>Firefox</dt>
+      <dt>Mozilla Firefox</dt>
+      <dt>Fx</dt>
+      <dd>
+        A free, open source, cross-platform,
+        graphical web browser developed by the
+        Mozilla Corporation and hundreds of
+        volunteers.
+      </dd>
+      <dd>
+        The Red Panda also known as the Lesser
+        Panda, Wah, Bear Cat or Firefox, is a
+        mostly herbivorous mammal, slightly larger
+        than a domestic cat (60 cm long).
+      </dd>
+    </dl>
+  </div>
+</div>
+</body>
+</html>

--- a/spec/fixtures/description_lists/test04.xml
+++ b/spec/fixtures/description_lists/test04.xml
@@ -1,0 +1,44 @@
+<w:p>
+  <w:pPr>
+    <w:pStyle w:val="Heading1"/>
+  </w:pPr>
+  <w:r>
+    <w:t xml:space="preserve">Heading</w:t>
+  </w:r>
+</w:p>
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Some text</w:t>
+  </w:r>
+</w:p>
+<w:p>
+  <w:r>
+    <w:t xml:space="preserve">Firefox</w:t>
+  </w:r>
+</w:p>
+<w:p>
+<w:r>
+  <w:t xml:space="preserve">Mozilla Firefox</w:t>
+</w:r>
+</w:p>
+<w:p>
+<w:r>
+  <w:t xml:space="preserve">Fx</w:t>
+</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:ind w:left="720"/>
+</w:pPr>
+<w:r>
+  <w:t xml:space="preserve">A free, open source, cross-platform, graphical web browser developed by the Mozilla Corporation and hundreds of volunteers.</w:t>
+</w:r>
+</w:p>
+<w:p>
+<w:pPr>
+  <w:ind w:left="720"/>
+</w:pPr>
+<w:r>
+  <w:t xml:space="preserve">The Red Panda also known as the Lesser Panda, Wah, Bear Cat or Firefox, is a mostly herbivorous mammal, slightly larger than a domestic cat (60 cm long).</w:t>
+</w:r>
+</w:p>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'htmltoword'
 include Htmltoword::XSLTHelper
 include Htmltoword::TemplatesHelper
 
-def compare_transformed_files(test, test_file_name, extras: false)
+def compare_transformed_files(test:, test_file_name:, extras: false)
   source = File.read(fixture_path(test, test_file_name, :html), encoding: 'utf-8')
   expected_content = File.read(fixture_path(test, test_file_name, :xml), encoding: 'utf-8')
   compare_resulting_wordml_with_expected(source, expected_content, extras: extras)
@@ -16,6 +16,7 @@ def compare_resulting_wordml_with_expected(html, resulting_wordml, extras: false
   result = Htmltoword::Document.new(template_file(nil)).transform_doc_xml(source, extras)
   result.gsub!(/\s*<!--(.*?)-->\s*/m, '')
   result = remove_declaration(result)
+
   expect(remove_whitespace(result)).to eq(remove_whitespace(resulting_wordml))
 end
 

--- a/spec/xslt_complex_spec.rb
+++ b/spec/xslt_complex_spec.rb
@@ -1241,6 +1241,10 @@ describe 'Bigger and a bit more complex documents' do
   end
 
   it 'transforms other nestings' do
-    compare_transformed_files('complex', 'nestings', extras: false)
+    compare_transformed_files(
+      test: 'complex',
+      test_file_name: 'nestings',
+      extras: false
+    )
   end
 end

--- a/spec/xslt_description_lists_spec.rb
+++ b/spec/xslt_description_lists_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe 'XSLT supporting description lists' do
+
+  it 'transforms correctly a single term and description' do
+    compare_transformed_files(
+      test: 'description_lists',
+      test_file_name: 'test01',
+      extras: false
+    )
+  end
+
+  it 'transforms correctly multiple terms, single description' do
+    compare_transformed_files(
+      test: 'description_lists',
+      test_file_name: 'test02',
+      extras: false
+    )
+  end
+
+  it 'transforms correctly a single term, multiple descriptions' do
+    compare_transformed_files(
+      test: 'description_lists',
+      test_file_name: 'test03',
+      extras: false
+    )
+  end
+
+  it 'transforms correctly a description list nested in divs' do
+    compare_transformed_files(
+      test: 'description_lists',
+      test_file_name: 'test04',
+      extras: false
+    )
+  end
+end

--- a/spec/xslt_lists_spec.rb
+++ b/spec/xslt_lists_spec.rb
@@ -649,6 +649,10 @@ describe "XSLT supporting lists" do
   end
 
   it 'handles inline elements inside a div' do
-    compare_transformed_files('lists', 'lists_inline_elements', extras: false)
+    compare_transformed_files(
+      test: 'lists',
+      test_file_name: 'lists_inline_elements',
+      extras: false
+    )
   end
 end


### PR DESCRIPTION
For very basic lists, not nested or complex structures within the `<dt>`or `<dd>` elements.