### PR TITLE
Rowspan support and aesthetic improvements for tables

### DIFF
--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -108,13 +108,10 @@ module Htmltoword
 
     def rowspan_walkaround(source)
       source.xpath('//td[@rowspan > 1]').each do |e|
-        cols = 0
         parent = e.parent
         tds = parent.children.to_a.filter{|ch| ch.name == 'td'}
-        tds.each do |ch|
-          cols += ch.attributes['colspan'] ? ch.attributes['colspan'].value.to_i : 1
-        end
         trs = parent.parent.children.to_a.filter{|ch| ch.name == 'tr'}
+        e_index = tds.index(e)
         e_colspan = e.attributes['colspan'] ? e.attributes['colspan'].value : 1
         parent_index = trs.index(parent)
         (e.attributes['rowspan'].value.to_i - 1).times do |i|
@@ -122,7 +119,7 @@ module Htmltoword
           tds = tr.children.to_a.filter{|ch| ch.name == 'td'}
           tds.inject(0) do |sum, ch|
             sum += ch.attributes['colspan'] ? ch.attributes['colspan'].value.to_i : 1
-            if sum == (cols - e_colspan)
+            if sum == (e_index + e_colspan)
               ch.add_previous_sibling "<td vmerge colspan=\"#{e_colspan}\"></td>"
               break
             end

--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -123,6 +123,9 @@ module Htmltoword
               ch.add_previous_sibling "<td vmerge colspan=\"#{e_colspan}\"></td>"
               break
             end
+            if tds.index(ch) == tds.length - 1
+              ch.add_next_sibling "<td vmerge colspan=\"#{e_colspan}\"></td>"
+            end
             sum
           end
         end

--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -116,8 +116,9 @@ module Htmltoword
         end
         trs = parent.parent.children.to_a.filter{|ch| ch.name == 'tr'}
         e_colspan = e.attributes['colspan'] ? e.attributes['colspan'].value : 1
+        parent_index = trs.index(parent)
         (e.attributes['rowspan'].value.to_i - 1).times do |i|
-          tr = trs[i+1]
+          tr = trs[i+parent_index+1]
           tds = tr.children.to_a.filter{|ch| ch.name == 'td'}
           tds.inject(0) do |sum, ch|
             sum += ch.attributes['colspan'] ? ch.attributes['colspan'].value.to_i : 1

--- a/lib/htmltoword/xslt/tables.xslt
+++ b/lib/htmltoword/xslt/tables.xslt
@@ -156,7 +156,10 @@
         <w:gridSpan w:val="{@colspan}"/>
       </xsl:if>
       <xsl:if test="@rowspan &gt; 1">
-        <w:vMerge w:val="{@rowspan}"/>
+        <w:vMerge w:val="restart"/>
+      </xsl:if>
+      <xsl:if test="@vmerge">
+        <w:vMerge/>
       </xsl:if>
     </w:tcPr>
   </xsl:template>

--- a/lib/htmltoword/xslt/tables.xslt
+++ b/lib/htmltoword/xslt/tables.xslt
@@ -157,11 +157,11 @@
       </xsl:if>
       <xsl:if test="@rowspan &gt; 1">
         <w:vMerge w:val="restart"/>
-        <w:vAlign w:val="center"/>
       </xsl:if>
       <xsl:if test="@vmerge">
         <w:vMerge/>
       </xsl:if>
+      <w:vAlign w:val="center"/>
     </w:tcPr>
   </xsl:template>
 

--- a/lib/htmltoword/xslt/tables.xslt
+++ b/lib/htmltoword/xslt/tables.xslt
@@ -161,6 +161,9 @@
       <xsl:if test="@vmerge">
         <w:vMerge/>
       </xsl:if>
+      <xsl:if test="@width">
+        <w:tcW w:val="{@width}"/>
+      </xsl:if>
       <w:vAlign w:val="center"/>
     </w:tcPr>
   </xsl:template>

--- a/lib/htmltoword/xslt/tables.xslt
+++ b/lib/htmltoword/xslt/tables.xslt
@@ -155,6 +155,9 @@
       <xsl:if test="@colspan &gt; 1">
         <w:gridSpan w:val="{@colspan}"/>
       </xsl:if>
+      <xsl:if test="@rowspan &gt; 1">
+        <w:vMerge w:val="{@rowspan}"/>
+      </xsl:if>
     </w:tcPr>
   </xsl:template>
 

--- a/lib/htmltoword/xslt/tables.xslt
+++ b/lib/htmltoword/xslt/tables.xslt
@@ -157,6 +157,7 @@
       </xsl:if>
       <xsl:if test="@rowspan &gt; 1">
         <w:vMerge w:val="restart"/>
+        <w:vAlign w:val="center"/>
       </xsl:if>
       <xsl:if test="@vmerge">
         <w:vMerge/>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -831,6 +831,7 @@ describe "XSLT for tables" do
       <w:tc>
         <w:tcPr>
           <w:vMerge w:val="restart"/>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p>
           <w:r>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -35,7 +35,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Hello</w:t>
@@ -92,7 +94,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Cell 1,1</w:t>
@@ -100,7 +104,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:tbl>
           <w:tblPr>
             <w:tblStyle w:val="TableGrid"/>
@@ -117,7 +123,9 @@ describe "XSLT for tables" do
           </w:tblPr>
           <w:tr>
             <w:tc>
-              <w:tcPr/>
+              <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
               <w:p>
                 <w:r>
                   <w:t xml:space="preserve">Nested</w:t>
@@ -125,7 +133,9 @@ describe "XSLT for tables" do
               </w:p>
             </w:tc>
             <w:tc>
-              <w:tcPr/>
+              <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
               <w:p>
                 <w:r>
                   <w:t xml:space="preserve">Table</w:t>
@@ -137,7 +147,9 @@ describe "XSLT for tables" do
         <w:p/>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Cell 1,3</w:t>
@@ -184,7 +196,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -195,7 +209,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p/>
       </w:tc>
     </w:tr>
@@ -244,7 +260,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -255,7 +273,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -268,7 +288,9 @@ describe "XSLT for tables" do
     </w:tr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -279,7 +301,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Cell 1,2</w:t>
@@ -330,7 +354,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -341,7 +367,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -354,7 +382,9 @@ describe "XSLT for tables" do
     </w:tr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:rPr>
@@ -365,7 +395,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Cell 1,2</w:t>
@@ -422,7 +454,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Hello</w:t>
@@ -430,7 +464,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">World</w:t>
@@ -460,7 +496,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Hello world</w:t>
@@ -468,7 +506,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Part 2</w:t>
@@ -523,7 +563,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Pre H1 </w:t>
@@ -544,7 +586,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Text </w:t>
@@ -573,7 +617,9 @@ describe "XSLT for tables" do
     </w:tr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Some content </w:t>
@@ -596,13 +642,17 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p/>
       </w:tc>
     </w:tr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Something </w:t>
@@ -630,7 +680,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Text inside div</w:t>
@@ -678,7 +730,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Sum total</w:t>
@@ -688,6 +742,7 @@ describe "XSLT for tables" do
       <w:tc>
         <w:tcPr>
           <w:shd w:val="clear" w:color="auto" w:fill="C3C3C3"/>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p>
           <w:r>
@@ -701,6 +756,7 @@ describe "XSLT for tables" do
             <w:bottom w:val="dashed" w:sz="6" w:space="0" w:color="red"/>
             <w:right w:val="single" w:sz="6" w:space="0" w:color="000000"/>
           </w:tcBorders>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p>
           <w:r>
@@ -749,6 +805,7 @@ describe "XSLT for tables" do
       <w:tc>
         <w:tcPr>
           <w:gridSpan w:val="4"/>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p>
           <w:r>
@@ -811,7 +868,9 @@ describe "XSLT for tables" do
     </w:tblPr>
     <w:tr>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Top Left</w:t>
@@ -819,7 +878,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Top Right</w:t>
@@ -840,7 +901,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Center 1</w:t>
@@ -848,7 +911,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Right 1</w:t>
@@ -860,11 +925,14 @@ describe "XSLT for tables" do
       <w:tc>
         <w:tcPr>
           <w:vMerge/>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p/>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Center 2</w:t>
@@ -872,7 +940,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Right 2</w:t>
@@ -884,11 +954,14 @@ describe "XSLT for tables" do
       <w:tc>
         <w:tcPr>
           <w:vMerge/>
+          <w:vAlign w:val="center"/>
         </w:tcPr>
         <w:p/>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Center 3</w:t>
@@ -896,7 +969,9 @@ describe "XSLT for tables" do
         </w:p>
       </w:tc>
       <w:tc>
-        <w:tcPr/>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Right 3</w:t>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -878,6 +878,7 @@ describe "XSLT for tables" do
       <tbody>
         <tr>
           <td>Top Left</td>
+          <td>Top Center</td>
           <td>Top Right</td>
         </tr>
         <tr>
@@ -923,6 +924,16 @@ describe "XSLT for tables" do
         <w:p>
           <w:r>
             <w:t xml:space="preserve">Top Left</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Top Center</w:t>
           </w:r>
         </w:p>
       </w:tc>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -819,6 +819,55 @@ describe "XSLT for tables" do
     compare_resulting_wordml_with_expected(html, expected_wordml.strip)
   end
 
+  it "transforms width into a tcW table cell property" do
+    html = <<-EOL
+  <!DOCTYPE html>
+  <html>
+  <head></head>
+  <body>
+    <table>
+      <tbody>
+        <tr>
+          <td width='400'>Hello</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+  </html>
+    EOL
+    expected_wordml = <<-EOL
+  <w:tbl>
+    <w:tblPr>
+      <w:tblStyle w:val="TableGrid"/>
+      <w:tblW w:w="5000" w:type="pct"/>
+      <w:tblBorders>
+        <w:top w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:left w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:bottom w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:right w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:insideH w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:insideV w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+      </w:tblBorders>
+      <w:tblLook w:val="0600" w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="1" w:noVBand="1"/>
+    </w:tblPr>
+    <w:tr>
+      <w:tc>
+        <w:tcPr>
+          <w:tcW w:val="400"/>
+          <w:vAlign w:val="center"/>
+        </w:tcPr>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Hello</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+    </w:tr>
+  </w:tbl>
+    EOL
+    compare_resulting_wordml_with_expected(html, expected_wordml.strip)
+  end
+
   it "transforms a rowspan into a vMerge table cell property" do
     html = <<-EOL
   <!DOCTYPE html>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -796,7 +796,7 @@ describe "XSLT for tables" do
     <w:tr>
       <w:tc>
         <w:tcPr>
-          <w:vMerge w:val="4"/>
+          <w:vMerge w:val="restart"/>
         </w:tcPr>
         <w:p>
           <w:r>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -771,6 +771,10 @@ describe "XSLT for tables" do
     <table>
       <tbody>
         <tr>
+          <td>Top Left</td>
+          <td>Top Right</td>
+        </tr>
+        <tr>
           <td rowspan='3'>Left x3</td>
           <td>Right 1</td>
         </tr>
@@ -802,6 +806,24 @@ describe "XSLT for tables" do
       </w:tblBorders>
       <w:tblLook w:val="0600" w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="1" w:noVBand="1"/>
     </w:tblPr>
+    <w:tr>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Top Left</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Top Right</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+    </w:tr>
     <w:tr>
       <w:tc>
         <w:tcPr>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -776,12 +776,15 @@ describe "XSLT for tables" do
         </tr>
         <tr>
           <td rowspan='3'>Left x3</td>
+          <td>Center 1</td>
           <td>Right 1</td>
         </tr>
         <tr>
+          <td>Center 2</td>
           <td>Right 2</td>
         </tr>
         <tr>
+          <td>Center 3</td>
           <td>Right 3</td>
         </tr>
       </tbody>
@@ -839,6 +842,14 @@ describe "XSLT for tables" do
         <w:tcPr/>
         <w:p>
           <w:r>
+            <w:t xml:space="preserve">Center 1</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
             <w:t xml:space="preserve">Right 1</w:t>
           </w:r>
         </w:p>
@@ -855,6 +866,14 @@ describe "XSLT for tables" do
         <w:tcPr/>
         <w:p>
           <w:r>
+            <w:t xml:space="preserve">Center 2</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
             <w:t xml:space="preserve">Right 2</w:t>
           </w:r>
         </w:p>
@@ -866,6 +885,14 @@ describe "XSLT for tables" do
           <w:vMerge/>
         </w:tcPr>
         <w:p/>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Center 3</w:t>
+          </w:r>
+        </w:p>
       </w:tc>
       <w:tc>
         <w:tcPr/>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -771,13 +771,22 @@ describe "XSLT for tables" do
     <table>
       <tbody>
         <tr>
-          <td rowspan='4'>Hello</td>
+          <td rowspan='3'>Left x3</td>
+          <td>Right 1</td>
+        </tr>
+        <tr>
+          <td>Right 2</td>
+        </tr>
+        <tr>
+          <td>Right 3</td>
         </tr>
       </tbody>
     </table>
   </body>
   </html>
     EOL
+    source = Nokogiri::HTML(html)
+    Htmltoword::Document.new('').rowspan_walkaround(source)
     expected_wordml = <<-EOL
   <w:tbl>
     <w:tblPr>
@@ -800,13 +809,53 @@ describe "XSLT for tables" do
         </w:tcPr>
         <w:p>
           <w:r>
-            <w:t xml:space="preserve">Hello</w:t>
+            <w:t xml:space="preserve">Left x3</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Right 1</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+    </w:tr>
+    <w:tr>
+      <w:tc>
+        <w:tcPr>
+          <w:vMerge/>
+        </w:tcPr>
+        <w:p/>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Right 2</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+    </w:tr>
+    <w:tr>
+      <w:tc>
+        <w:tcPr>
+          <w:vMerge/>
+        </w:tcPr>
+        <w:p/>
+      </w:tc>
+      <w:tc>
+        <w:tcPr/>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Right 3</w:t>
           </w:r>
         </w:p>
       </w:tc>
     </w:tr>
   </w:tbl>
     EOL
-    compare_resulting_wordml_with_expected(html, expected_wordml.strip)
+    compare_resulting_wordml_with_expected(source.to_s, expected_wordml.strip)
   end
 end

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -761,4 +761,52 @@ describe "XSLT for tables" do
     EOL
     compare_resulting_wordml_with_expected(html, expected_wordml.strip)
   end
+
+  it "transforms a rowspan into a vMerge table cell property" do
+    html = <<-EOL
+  <!DOCTYPE html>
+  <html>
+  <head></head>
+  <body>
+    <table>
+      <tbody>
+        <tr>
+          <td rowspan='4'>Hello</td>
+        </tr>
+      </tbody>
+    </table>
+  </body>
+  </html>
+    EOL
+    expected_wordml = <<-EOL
+  <w:tbl>
+    <w:tblPr>
+      <w:tblStyle w:val="TableGrid"/>
+      <w:tblW w:w="5000" w:type="pct"/>
+      <w:tblBorders>
+        <w:top w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:left w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:bottom w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:right w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:insideH w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+        <w:insideV w:val="none" w:sz="0" w:space="0" w:color="auto"/>
+      </w:tblBorders>
+      <w:tblLook w:val="0600" w:firstRow="0" w:lastRow="0" w:firstColumn="0" w:lastColumn="0" w:noHBand="1" w:noVBand="1"/>
+    </w:tblPr>
+    <w:tr>
+      <w:tc>
+        <w:tcPr>
+          <w:vMerge w:val="4"/>
+        </w:tcPr>
+        <w:p>
+          <w:r>
+            <w:t xml:space="preserve">Hello</w:t>
+          </w:r>
+        </w:p>
+      </w:tc>
+    </w:tr>
+  </w:tbl>
+    EOL
+    compare_resulting_wordml_with_expected(html, expected_wordml.strip)
+  end
 end


### PR DESCRIPTION
## Changelog
* Add support for simple rowspan in tables based on `slowpilot:feature/rowspan`
* Auto-align vertically all table cells by default
* Add width attribute as tcW to table cells

Example of `rowspan="3"` on the "Left x3" cell:
<img width="810" alt="Screen Shot 2021-08-02 at 17 08 34" src="https://user-images.githubusercontent.com/888004/127924170-3f3c613b-1ec6-4773-ae1c-80f08d9e673e.png">
