### PR TITLE
Fix text style combinations rendering

### DIFF
--- a/lib/htmltoword/xslt/base.xslt
+++ b/lib/htmltoword/xslt/base.xslt
@@ -302,19 +302,44 @@
   <xsl:template match="text()">
     <xsl:if test="string-length(.) > 0">
       <w:r>
-        <xsl:if test="ancestor::i">
+        <xsl:if test="ancestor::i and not(ancestor::b) and not(ancestor::u)">
           <w:rPr>
             <w:i />
           </w:rPr>
         </xsl:if>
-        <xsl:if test="ancestor::b">
+        <xsl:if test="ancestor::b and not(ancestor::i) and not(ancestor::u)">
           <w:rPr>
             <w:b />
           </w:rPr>
         </xsl:if>
-        <xsl:if test="ancestor::u">
+        <xsl:if test="ancestor::i and ancestor::b and not(ancestor::u)">
+          <w:rPr>
+            <w:i />
+            <w:b />
+          </w:rPr>
+        </xsl:if>
+        <xsl:if test="ancestor::u and not(ancestor::b) and not(ancestor::i)">
           <w:rPr>
             <w:u w:val="single"/>
+          </w:rPr>
+        </xsl:if>
+        <xsl:if test="ancestor::u and ancestor::b">
+          <w:rPr>
+            <w:u w:val="single"/>
+            <w:b />
+          </w:rPr>
+        </xsl:if>
+        <xsl:if test="ancestor::u and ancestor::i">
+          <w:rPr>
+            <w:u w:val="single"/>
+            <w:i />
+          </w:rPr>
+        </xsl:if>
+        <xsl:if test="ancestor::u and ancestor::i and ancestor::b">
+          <w:rPr>
+            <w:u w:val="single"/>
+            <w:i />
+            <w:b />
           </w:rPr>
         </xsl:if>
         <xsl:if test="ancestor::s">

--- a/spec/xslt_heading_spec.rb
+++ b/spec/xslt_heading_spec.rb
@@ -703,8 +703,6 @@ Using table-bordered class
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve"> and strong em </w:t>

--- a/spec/xslt_simple_text_style_spec.rb
+++ b/spec/xslt_simple_text_style_spec.rb
@@ -175,8 +175,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Bold italic</w:t>
@@ -187,8 +185,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Italic bold</w:t>
@@ -199,8 +195,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Bold em</w:t>
@@ -212,8 +206,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Em bold</w:t>
@@ -224,8 +216,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Strong italic</w:t>
@@ -236,8 +226,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Italic strong</w:t>
@@ -249,8 +237,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Strong em</w:t>
@@ -261,8 +247,6 @@ Combinations in p tag: </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Em strong</w:t>
@@ -286,8 +270,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Bold italic.</w:t>
@@ -311,8 +293,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Italic bold.</w:t>
@@ -336,8 +316,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Bold em</w:t>
@@ -361,8 +339,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Em bold.</w:t>
@@ -386,8 +362,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Strong italic. </w:t>
@@ -411,8 +385,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Italic strong. </w:t>
@@ -436,8 +408,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Strong em. </w:t>
@@ -461,8 +431,6 @@ More on combinations : </w:t>
     <w:r>
       <w:rPr>
         <w:i/>
-      </w:rPr>
-      <w:rPr>
         <w:b/>
       </w:rPr>
       <w:t xml:space="preserve">Em strong.</w:t>
@@ -634,8 +602,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Strong em </w:t>
@@ -655,8 +621,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Bold italic</w:t>
@@ -687,8 +651,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Em strong text</w:t>
@@ -708,8 +670,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Italic bold</w:t>
@@ -753,8 +713,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Strong em </w:t>
@@ -774,8 +732,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Bold italic</w:t>
@@ -805,8 +761,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Strong italic</w:t>
@@ -816,8 +770,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Bold Em</w:t>
@@ -845,8 +797,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Strong em</w:t>
@@ -890,8 +840,6 @@ More on combinations : </w:t>
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve">Italic strong</w:t>

--- a/spec/xslt_tables_spec.rb
+++ b/spec/xslt_tables_spec.rb
@@ -621,8 +621,6 @@ describe "XSLT for tables" do
           <w:r>
             <w:rPr>
               <w:i/>
-            </w:rPr>
-            <w:rPr>
               <w:b/>
             </w:rPr>
             <w:t xml:space="preserve"> and strong em </w:t>


### PR DESCRIPTION
I've been using this solution for months and haven't encountered any issues, so I wanted to share 👍 

### The Issue
Generated documents with multiple text styles applied, e.g. `<b><i>some text</i></b>`, were only being displayed with one of those styles applied when opened in Word (version 16.70). 

For example, a piece of text that's underlined, bold, and italic would only appear as italic in Word.

The issue occurs when Word renders some text that has this kind of formatting, with separate `<w:rPr>` tags for each style:
```
<w:r>
  <w:rPr>
    <w:i/>
  </w:rPr>
  <w:rPr>
    <w:b/>
  </w:rPr>
  <w:t xml:space="preserve">some text</w:t>
</w:r>
```
Word will only display one `<w:rPr>` at a time, so in this case the text would appear to only be italic.

### The Solution
I added explicit checks within `base.xlst` for each combination of formatting. This results in a singular `<w:rPr>` tag for each block of formatted text, as opposed to a separate tag for each style. 

I also updated the spec files to reflect this change. 